### PR TITLE
Issue #30 Bug Fix: Reformat Order Time

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -20,6 +20,10 @@ class ViewOrders extends Component {
             });
     }
 
+    formattedTime(time){
+        return time.toTimeString().split(' ')[0];
+    }
+
     render() {
         return (
             <Template>
@@ -33,7 +37,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {`${this.formattedTime(createdDate)}`}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
Formats the seconds and minutes portion of the time to allow for leading zeroes when necessary. 